### PR TITLE
Fix input data encoding

### DIFF
--- a/join-welcome/handler.py
+++ b/join-welcome/handler.py
@@ -7,7 +7,9 @@ import hmac
 from time import perf_counter
 
 def handle(event, context):
-    # TODO implement
+    SLACK_SIG_HEADER = "X-Slack-Signature"
+    SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp"
+    
     log_event(event.body)
 
     if os.getenv("log_env", "0") == "1":
@@ -15,7 +17,7 @@ def handle(event, context):
 
     r = None
     try:
-        r  = json.loads(event.body)
+        r = json.loads(event.body)
     except ValueError:
         sys.stderr.write("Error parsing request, invalid JSON")
         return {
@@ -40,13 +42,13 @@ def handle(event, context):
 
     target_channel = os.getenv("target_channel")
     digest = ""
-    if "Http_X_Slack_Signature" in event.headers:
-        digest = event.headers["Http_X_Slack_Signature"]
+    if SLACK_SIG_HEADER in event.headers:
+        digest = event.headers[SLACK_SIG_HEADER]
 
-    # Takes format of: "Http_X_Slack_Signature v0=hash"
+    # Takes format of: "X-Slack-Signature v0=hash"
     slack_request_timestamp = ""
-    if "Http_X_Slack_Request_Timestamp" in event.headers:
-        slack_request_timestamp = event.headers["Http_X_Slack_Request_Timestamp"]
+    if SLACK_TIMESTAMP_HEADER in event.headers:
+        slack_request_timestamp = event.headers[SLACK_TIMESTAMP_HEADER]
 
     input = f"v0:{slack_request_timestamp}:{event.body}"
 

--- a/join-welcome/handler.py
+++ b/join-welcome/handler.py
@@ -10,14 +10,17 @@ def handle(event, context):
     SLACK_SIG_HEADER = "X-Slack-Signature"
     SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp"
     
-    log_event(event.body)
+    # Convert bytestring to python3 default encoding (utf-8)
+    body = event.body.decode()
+
+    log_event(body)
 
     if os.getenv("log_env", "0") == "1":
         log_env()
 
     r = None
     try:
-        r = json.loads(event.body)
+        r = json.loads(body)
     except ValueError:
         sys.stderr.write("Error parsing request, invalid JSON")
         return {
@@ -50,7 +53,7 @@ def handle(event, context):
     if SLACK_TIMESTAMP_HEADER in event.headers:
         slack_request_timestamp = event.headers[SLACK_TIMESTAMP_HEADER]
 
-    input = f"v0:{slack_request_timestamp}:{event.body}"
+    input = f"v0:{slack_request_timestamp}:{body}"
 
     start = perf_counter()
     is_valid_hmac = valid_hmac(signing_secret, input, get_hash(digest))

--- a/stack.yml
+++ b/stack.yml
@@ -31,7 +31,7 @@ functions:
       slack_url: "https://zoom.us/j/4215401314"
 
   join-welcome:
-    lang: python3
+    lang: python3-http
     handler: ./join-welcome
     image: alexellis/join-welcome:1.0
     labels:


### PR DESCRIPTION
Request data is read in as a bytestring via Flask, so this PR will convert the data to the default python 3 encoding (utf-8).

I tested it by creating a local function with HMAC using the python3-http template and it was able to successfully validate the HMAC signature once the input is encoded to utf-8.