### PR TITLE
Convert bytestring to default python3 encoding

### DIFF
--- a/join-welcome/handler.py
+++ b/join-welcome/handler.py
@@ -10,14 +10,17 @@ def handle(event, context):
     SLACK_SIG_HEADER = "X-Slack-Signature"
     SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp"
     
-    log_event(event.body)
+    # Convert bytestring to python3 default encoding (utf-8)
+    body = event.body.decode()
+
+    log_event(body)
 
     if os.getenv("log_env", "0") == "1":
         log_env()
 
     r = None
     try:
-        r = json.loads(event.body)
+        r = json.loads(body)
     except ValueError:
         sys.stderr.write("Error parsing request, invalid JSON")
         return {
@@ -50,7 +53,7 @@ def handle(event, context):
     if SLACK_TIMESTAMP_HEADER in event.headers:
         slack_request_timestamp = event.headers[SLACK_TIMESTAMP_HEADER]
 
-    input = f"v0:{slack_request_timestamp}:{event.body}"
+    input = f"v0:{slack_request_timestamp}:{body}"
 
     sys.stderr.write("Input: '{}'\n".format(input))
 


### PR DESCRIPTION
Request data is read in as a byte string via Flask, so this PR will convert the data to the default python 3 encoding (utf-8).

I tested it by creating a local function with HMAC using the python3-http template and it was able to successfully validate the HMAC signature once the input is encoded to utf-8.

Signed-off-by: Kevin Turcios <kevin_turcios@outlook.com>